### PR TITLE
Give the bonds a bit longer to form in tests

### DIFF
--- a/diagnostic_aggregator/test/add_analyzers_test.py
+++ b/diagnostic_aggregator/test/add_analyzers_test.py
@@ -81,7 +81,7 @@ class TestAddAnalyzer(unittest.TestCase):
     def wait_for_agg(self):
         self.agg_msgs = {}
         while not self.agg_msgs and not rospy.is_shutdown():
-            rospy.sleep(rospy.Duration(1))
+            rospy.sleep(rospy.Duration(3))
 
     def test_add_agg(self):
         self.wait_for_agg()


### PR DESCRIPTION
This was failing on our jenkins as it was too short.

As it is, it's a bit unreliable for a test as the bonds may not have yet been formed but a new message with the diagnostics in the 'Other' can arrive and this will fail the test. Might not be worth doing anything complicated though if a reasonable timeout does the job.
